### PR TITLE
Add EventLog

### DIFF
--- a/Pansynchro.Connections.MSSQL/MetadataHelper.cs
+++ b/Pansynchro.Connections.MSSQL/MetadataHelper.cs
@@ -6,6 +6,7 @@ using Microsoft.Data.SqlClient;
 
 using Pansynchro.Core;
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.EventsSystem;
 using Pansynchro.SQL;
 
 namespace Pansynchro.Connectors.MSSQL
@@ -185,8 +186,8 @@ THEN INSERT ({3}) VALUES ({4});";
 				name, $"Pansynchro.[{name}]", pkMatch, inserterCols, inserterVals);
 			try {
 				conn.Execute(SQL);
-			} catch (SqlException) {
-				Console.WriteLine($"SqlException while writing query:{Environment.NewLine}{SQL}");
+			} catch (SqlException ex) {
+				EventLog.Instance.AddErrorEvent(ex, name, $"SqlException while writing query:{Environment.NewLine}{SQL}");
 				throw;
 			}
 			if (hasID) {
@@ -217,8 +218,8 @@ THEN INSERT ({5}) VALUES ({6});";
 				name.Namespace, name.Name, $"Pansynchro.[{name.Name}]", pkMatch, updater, inserterCols, inserterVals);
 			try {
 				conn.Execute(SQL);
-			} catch (SqlException) {
-				Console.WriteLine($"SqlException while writing query:{Environment.NewLine}{SQL}");
+			} catch (SqlException ex) {
+				EventLog.Instance.AddErrorEvent(ex, name, $"SqlException while writing query:{Environment.NewLine}{SQL}");
 				throw;
 			}
 			if (hasID) {

--- a/Pansynchro.Connections.MSSQL/Pansynchro.Connectors.MSSQL.csproj
+++ b/Pansynchro.Connections.MSSQL/Pansynchro.Connectors.MSSQL.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Identity" Version="1.10.4" />
+    <PackageReference Include="Azure.Identity" Version="1.12.0" />
     <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.4" />
     <PackageReference Include="Microsoft.SqlServer.Types" Version="160.1000.6" />
   </ItemGroup>

--- a/Pansynchro.Connections.MySql/MySqlWriter.cs
+++ b/Pansynchro.Connections.MySql/MySqlWriter.cs
@@ -9,6 +9,8 @@ using MySqlConnector;
 
 using Pansynchro.Core;
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.Errors;
+using Pansynchro.Core.EventsSystem;
 
 namespace Pansynchro.Connectors.MySQL
 {
@@ -26,7 +28,7 @@ namespace Pansynchro.Connectors.MySQL
         {
             foreach (var err in args.Errors)
             {
-                Console.WriteLine($"{err.Level}: {err.Message}");
+                EventLog.Instance.AddErrorEvent(null, null, $"{err.Level}: {err.Message}");
             }
         }
 
@@ -34,21 +36,31 @@ namespace Pansynchro.Connectors.MySQL
 
         public async Task Sync(IAsyncEnumerable<DataStream> streams, DataDictionary dest)
         {
+            EventLog.Instance.AddStartSyncEvent();
             await foreach (var (name, averageSize, reader) in streams) {
-                ulong progress = 0;
-                var copy = new MySqlBulkCopy(_conn) {
-                    DestinationTableName = $"`{name}`",
-                    NotifyAfter = BATCH_SIZE
-                };
-                copy.MySqlRowsCopied += (s, e) => progress = (ulong)e.RowsCopied;
-                copy.ColumnMappings.AddRange(GetColumnMapping(reader));
-                var stopwatch = new Stopwatch();
-                stopwatch.Start();
-                copy.WriteToServer(reader);
-                stopwatch.Stop();
-                reader.Dispose();
+                EventLog.Instance.AddStartSyncStreamEvent(name);
+                try {
+                    ulong progress = 0;
+                    var copy = new MySqlBulkCopy(_conn) {
+                        DestinationTableName = $"`{name}`",
+                        NotifyAfter = BATCH_SIZE
+                    };
+                    copy.MySqlRowsCopied += (s, e) => progress = (ulong)e.RowsCopied;
+                    copy.ColumnMappings.AddRange(GetColumnMapping(reader));
+                    var stopwatch = new Stopwatch();
+                    stopwatch.Start();
+                    copy.WriteToServer(reader);
+                    stopwatch.Stop();
+                } catch (Exception ex) {
+                    EventLog.Instance.AddErrorEvent(ex, name);
+                    if (!ErrorManager.ContinueOnError)
+                        throw;
+                } finally {
+                    reader.Dispose();
+                }
+                EventLog.Instance.AddEndSyncStreamEvent(name);
             }
-            Console.WriteLine("Finished!");
+            EventLog.Instance.AddEndSyncEvent();
         }
 
         private static IEnumerable<MySqlBulkCopyColumnMapping> GetColumnMapping(IDataReader reader) =>

--- a/Pansynchro.Connectors.Debug/ConsoleWriter.cs
+++ b/Pansynchro.Connectors.Debug/ConsoleWriter.cs
@@ -4,6 +4,8 @@ using System.Threading.Tasks;
 
 using Pansynchro.Core;
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.Errors;
+using Pansynchro.Core.EventsSystem;
 
 namespace Pansynchro.Connectors.Debug
 {
@@ -11,14 +13,24 @@ namespace Pansynchro.Connectors.Debug
 	{
 		public async Task Sync(IAsyncEnumerable<DataStream> streams, DataDictionary dest)
 		{
+			EventLog.Instance.AddStartSyncEvent();
 			Console.OutputEncoding = System.Text.Encoding.UTF8;
 			await foreach (var stream in streams) {
+				EventLog.Instance.AddStartSyncStreamEvent(stream.Name);
 				var buffer = new object[stream.Reader.FieldCount];
-				while (stream.Reader.Read()) {
-					stream.Reader.GetValues(buffer);
-					Console.WriteLine(buffer.Length > 1 ? string.Join(", ", buffer) : buffer[0]);
+				try {
+					while (stream.Reader.Read()) {
+						stream.Reader.GetValues(buffer);
+						Console.WriteLine(buffer.Length > 1 ? string.Join(", ", buffer) : buffer[0]);
+					}
+				} catch (Exception ex) {
+					EventLog.Instance.AddErrorEvent(ex, stream.Name);
+					if (!ErrorManager.ContinueOnError)
+						throw;
 				}
+				EventLog.Instance.AddEndSyncStreamEvent(stream.Name);
 			}
+			EventLog.Instance.AddEndSyncEvent();
 		}
 
 		public void Dispose()

--- a/Pansynchro.Connectors.Postgres/MetadataHelper.cs
+++ b/Pansynchro.Connectors.Postgres/MetadataHelper.cs
@@ -150,7 +150,7 @@ WHERE constraint_type = 'PRIMARY KEY' and tc.table_name = :tableName and c.table
 		internal static void MergeTable(NpgsqlConnection conn, string table, string namespace_)
 		{
 			var columns = PostgresHelper.ReadStrings(
-					conn, EXTRACT_COLUMNS, 
+					conn, EXTRACT_COLUMNS,
 					new KeyValuePair<string, object>("tableName", table),
 					new KeyValuePair<string, object>("tableSchema", namespace_))
 				.Select(c => '"' + c + '"')
@@ -160,12 +160,9 @@ WHERE constraint_type = 'PRIMARY KEY' and tc.table_name = :tableName and c.table
 					new KeyValuePair<string, object>("tableName", table),
 					new KeyValuePair<string, object>("tableSchema", namespace_))
 				.ToArray();
-			if (pkColumns.Length == 0)
-			{
+			if (pkColumns.Length == 0) {
 				CopyData(conn, table, namespace_, columns);
-			}
-			else
-			{
+			} else {
 				var nonPkColumns = columns.Except(pkColumns).ToArray();
 				if (nonPkColumns.Length == 0) {
 					MergeLinkingTable(conn, table, namespace_, columns, pkColumns);
@@ -210,21 +207,21 @@ DO UPDATE SET {5}";
 			conn.Execute(SQL);
 		}
 
-        const string COPY_DATA_TEMPLATE =
+		const string COPY_DATA_TEMPLATE =
 @"INSERT INTO ""{0}"".""{1}"" ({2})
 select {2} from {3}";
 
-        public static void CopyData(NpgsqlConnection conn, string name, string namespace_, string[] columns)
-        {
-            var formatter = PostgresFormatter.Instance;
-            var inserterCols = string.Join(", ", columns);
-            var inserterVals = string.Join(", ", columns.Select(c => "SOURCE." + c));
-            var SQL = string.Format(CultureInfo.InvariantCulture, COPY_DATA_TEMPLATE,
-                namespace_, name, inserterCols, $"Pansynchro.{formatter.QuoteName(name)}");
-            conn.Execute(SQL);
-        }
+		public static void CopyData(NpgsqlConnection conn, string name, string namespace_, string[] columns)
+		{
+			var formatter = PostgresFormatter.Instance;
+			var inserterCols = string.Join(", ", columns);
+			var inserterVals = string.Join(", ", columns.Select(c => "SOURCE." + c));
+			var SQL = string.Format(CultureInfo.InvariantCulture, COPY_DATA_TEMPLATE,
+				namespace_, name, inserterCols, $"Pansynchro.{formatter.QuoteName(name)}");
+			conn.Execute(SQL);
+		}
 
-        private static string CorrespondColumns(string[] columns, string separator, string joiner)
+		private static string CorrespondColumns(string[] columns, string separator, string joiner)
 		{
 			return string.Join(joiner, columns.Select(c => $"{c} {separator} excluded.{c}"));
 		}

--- a/Pansynchro.Connectors.Postgres/Pansynchro.Connectors.Postgres.csproj
+++ b/Pansynchro.Connectors.Postgres/Pansynchro.Connectors.Postgres.csproj
@@ -24,7 +24,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Npgsql" Version="8.0.1" />
+	<PackageReference Include="Npgsql" Version="8.0.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Pansynchro.Connectors.TextFile/CSV/CsvDataReader.cs
+++ b/Pansynchro.Connectors.TextFile/CSV/CsvDataReader.cs
@@ -361,12 +361,12 @@ namespace Pansynchro.Connectors.TextFile.CSV
 					if (hasChar) {
 						string subString = offset == 0 ? text.Substring(offset, i) : text.Substring(offset, i - offset);
 						word = NormalizeString(subString.Replace("\\", String.Empty), quoteChar);
-						splitStrings.Add(word);
+						splitStrings.Add(word!);
 						hasChar = false;
 					} else {
 						string subString = offset == 0 ? text.Substring(offset, i) : text.Substring(offset, i - offset);
 						word = NormalizeString(subString, quoteChar);
-						splitStrings.Add(word);
+						splitStrings.Add(word!);
 						i = i + len;
 					}
 					offset = i + 1;
@@ -376,8 +376,8 @@ namespace Pansynchro.Connectors.TextFile.CSV
 
 			if (offset <= text.Length)
 				splitStrings.Add(hasChar 
-					? NormalizeString(text.Substring(offset).Replace("\\", String.Empty), quoteChar)
-					: NormalizeString(text.Substring(offset), quoteChar));
+					? NormalizeString(text.Substring(offset).Replace("\\", String.Empty), quoteChar)!
+					: NormalizeString(text.Substring(offset), quoteChar)!);
 
 			return splitStrings.ToArray();
 		}

--- a/Pansynchro.Connectors.TextFile/JSON/JsonConfigurator.cs
+++ b/Pansynchro.Connectors.TextFile/JSON/JsonConfigurator.cs
@@ -51,18 +51,19 @@ namespace Pansynchro.Connectors.TextFile.JSON
             }
         }
 
+        [AllowNull]
         public override object this[string keyword]
         {
             get => keyword == "Streams" ? Streams : base[keyword];
             set {
                 if (keyword == "Streams") {
-                    Streams = (ObservableCollection<JsonConf>)value;
+                    Streams = (ObservableCollection<JsonConf>)value!;
                 } else {
                     var existing = Streams.FirstOrDefault(s => s.Name.ToLowerInvariant() == keyword.ToLowerInvariant());
                     if (existing != null) {
                         Streams.Remove(existing);
                     }
-                    var newStream = JsonConvert.DeserializeObject<JsonConf>((string)value);
+                    var newStream = JsonConvert.DeserializeObject<JsonConf>((string)value!);
                     if (newStream?.Name.ToLowerInvariant() != keyword.ToLowerInvariant()) {
                         throw new ArgumentException($"Invalid stream name: {keyword}");
                     }

--- a/Pansynchro.Connectors.TextFile/WholeFile/TextFileWriter.cs
+++ b/Pansynchro.Connectors.TextFile/WholeFile/TextFileWriter.cs
@@ -5,6 +5,8 @@ using System.Threading.Tasks;
 
 using Pansynchro.Core;
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.Errors;
+using Pansynchro.Core.EventsSystem;
 
 namespace Pansynchro.Connectors.TextFile.WholeFile
 {
@@ -17,16 +19,24 @@ namespace Pansynchro.Connectors.TextFile.WholeFile
             if (_sink == null) {
                 throw new DataException("Must call SetDataSink before calling Sync");
             }
+            EventLog.Instance.AddStartSyncEvent();
             await foreach (var (name, settings, stream) in streams) {
+                EventLog.Instance.AddStartSyncStreamEvent(name);
                 try {
                     using var writer = await _sink.WriteText(name.ToString());
                     while (stream.Read()) {
                         writer.Write(stream.GetString(stream.GetOrdinal("Value")));
                     }
+                } catch (Exception ex) {
+                    EventLog.Instance.AddErrorEvent(ex, name);
+                    if (!ErrorManager.ContinueOnError)
+                        throw;
                 } finally {
                     stream.Dispose();
                 }
+                EventLog.Instance.AddEndSyncStreamEvent(name);
             }
+            EventLog.Instance.AddEndSyncEvent();
         }
 
         public void SetDataSink(IDataSink sink) => _sink = sink;

--- a/Pansynchro.Protocol/BinaryDecoder.cs
+++ b/Pansynchro.Protocol/BinaryDecoder.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json.Linq;
 using Pansynchro.Core;
 using Pansynchro.Core.CustomTypes;
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.EventsSystem;
 using Pansynchro.Core.Streams;
 
 namespace Pansynchro.Protocol
@@ -222,7 +223,7 @@ namespace Pansynchro.Protocol
 				yield return new DataStream(streamName, StreamSettings.None, new StreamingReader(_reader, schema, dict, mode, () => locked = false));
 			}
 			CheckEqual(_reader.ReadByte(), (byte)Markers.End, "Expected end of stream not found.");
-			Console.WriteLine($"Bytes read: {_meter.TotalBytesRead.ToString("N0")}");
+			EventLog.Instance.AddInformationEvent($"Bytes read: {_meter.TotalBytesRead.ToString("N0")}");
 			await Task.CompletedTask; // just to shut the compiler up
 		}
 

--- a/Pansynchro.SQL/SqlDbReader.cs
+++ b/Pansynchro.SQL/SqlDbReader.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using Pansynchro.Core;
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.EventsSystem;
 using Pansynchro.Core.Incremental;
 using Pansynchro.SQL;
 
@@ -136,9 +137,8 @@ namespace Pansynchro.SQL
                 var streams = source.Streams.ToDictionary(s => s.Name);
                 foreach (var name in source.DependencyOrder.SelectMany(s => s)) {
                     var stream = streams[name];
-                    Console.WriteLine($"{DateTime.Now}: Reading table '{stream.Name}'");
                     var recordSize = PayloadSizeAnalyzer.AverageSize(_conn, stream, SqlFormatter, _tran);
-                    Console.WriteLine($"{DateTime.Now}: Average data size: {recordSize}");
+                    EventLog.Instance.AddReadingStreamEvent(stream.Name, $"Average data size: {recordSize}");
                     _getReader = FullSyncReader;
                     var fullIncremental = false;
                     if (_incrementalPlan != null) {

--- a/Pansynchro.SQL/SqlSchemaAnalyzer.cs
+++ b/Pansynchro.SQL/SqlSchemaAnalyzer.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 
 using Pansynchro.Core;
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.EventsSystem;
 using Pansynchro.Core.Incremental;
 
 namespace Pansynchro.SQL
@@ -165,10 +166,7 @@ namespace Pansynchro.SQL
 				}
 			}
 			if (cycles > 0) {
-				Console.ForegroundColor = ConsoleColor.Red;
-				Console.Error.Write("WARNING: ");
-				Console.ResetColor();
-				Console.Error.WriteLine($"Circular refernces found in {cycles} tables.  Sync errors may occur if foreign key constraints are enabled on the destination database.");
+				EventLog.Instance.AddWarningEvent($"Circular refernces found in {cycles} tables.  Sync errors may occur if foreign key constraints are enabled on the destination database.");
 			}
 		}
 

--- a/Pansynchro.core/Errors/ErrorManager.cs
+++ b/Pansynchro.core/Errors/ErrorManager.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.Errors;
+public class ErrorManager
+{
+	private static bool continueOnError = false;
+	public static bool ContinueOnError { get { return continueOnError; } }
+	public static void DisableContinueOnError() { continueOnError = false; }
+	public static void EnableContinueOnError() { continueOnError = true; }
+
+}

--- a/Pansynchro.core/EventsSystem/EventBase.cs
+++ b/Pansynchro.core/EventsSystem/EventBase.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+using Pansynchro.Core.EventsSystem.Events;
+using System;
+using System.Text;
+
+namespace Pansynchro.Core.EventsSystem;
+public abstract class EventBase : IEvent
+{
+	public string Name { get; }
+	public DateTime FireOn { get; }
+	public LogLevel LogLevel { get; protected set; } = LogLevel.Information;
+	public string? Message { get; protected set; }
+
+	protected EventBase(string? message)
+	{
+		Name = this.GetType().Name;
+		FireOn = DateTime.Now;
+		Message = message;
+	}
+
+	public override string ToString()
+	{
+		var text = new StringBuilder(Name);
+
+		if (this is IStreamEvent streamEvent) {
+			text.Append($" {streamEvent.StreamName}");
+		}
+
+		if (Message is not null) {
+			text = text.Append($" {Message}");
+		}
+
+		if (this is ExceptionEvent exceptionEvent && exceptionEvent.Exception is not null) {
+			text.AppendLine();
+			text.Append(exceptionEvent.Exception.ToString());
+		}
+		return text.ToString();
+	}
+}

--- a/Pansynchro.core/EventsSystem/EventLog.cs
+++ b/Pansynchro.core/EventsSystem/EventLog.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.Extensions.Logging;
+using Pansynchro.Core.EventsSystem.Events;
+using Pansynchro.Core.Logs.ColorConsoleLogger;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Metadata;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem;
+
+public class EventLog
+{
+	private EventLog() { }
+
+	public static EventLog Instance { get; } = new EventLog();
+
+	private bool consoleOutput = true;
+	private List<IEvent> events = new List<IEvent>();
+
+	private ILogger _logger = new ColorConsoleLogger("Pansynchro", () => new ColorConsoleLoggerConfiguration());
+
+	public bool ConsoleOutput { get { return consoleOutput; } }
+
+	public void DisableConsoleOutput() { consoleOutput = false; }
+	public void EnableConsoleOutput() { consoleOutput = true; }
+
+	public void SetDotNetLogger(ILogger logger) { _logger = logger; }
+
+	public IEnumerable<IEvent> GetEvents() { return events.ToArray(); }
+
+	public void AddEvent(IEvent @event)
+	{
+		events.Add(@event);
+		_logger?.LogEvent(@event);
+
+	}
+}

--- a/Pansynchro.core/EventsSystem/EventLogExtensions.cs
+++ b/Pansynchro.core/EventsSystem/EventLogExtensions.cs
@@ -1,0 +1,76 @@
+﻿using Pansynchro.Core.EventsSystem.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem;
+public static class EventLogExtensions
+{
+	public static void AddStartSyncEvent(this EventLog eventlog)
+	{
+		eventlog.AddEvent(new StartSyncEvent());
+	}
+
+	public static void AddStartSyncStreamEvent(this EventLog eventlog, StreamDescription stream)
+	{
+		eventlog.AddEvent(new StartSyncStreamEvent(stream.ToString()));
+	}
+
+	public static void AddReadingStreamEvent(this EventLog eventlog, StreamDescription stream, string? message)
+	{
+		eventlog.AddEvent(new ReadingStreamEvent(stream.ToString(), message));
+	}
+
+	public static void AddWritingStreamEvent(this EventLog eventlog, StreamDescription stream)
+	{
+		eventlog.AddEvent(new WritingStreamEvent(stream.ToString()));
+	}
+
+	public static void AddEndSyncStreamEvent(this EventLog eventlog, StreamDescription stream)
+	{
+		eventlog.AddEvent(new EndSyncStreamEvent(stream.ToString()));
+	}
+
+	public static void AddMergingStreamEvent(this EventLog eventlog, StreamDescription stream)
+	{
+		eventlog.AddEvent(new MergingStreamEvent(stream.ToString()));
+	}
+
+	public static void AddTruncatingStreamEvent(this EventLog eventlog, StreamDescription stream)
+	{
+		eventlog.AddEvent(new TruncatingStreamEvent(stream.ToString()));
+	}
+
+	public static void AddEndSyncEvent(this EventLog eventlog)
+	{
+		eventlog.AddEvent(new EndSyncEvent());
+	}
+
+	public static void AddUseTransformerEvent(this EventLog eventlog, ITransformer tr)
+	{
+		eventlog.AddEvent(new UseTransformerEvent(tr.GetType().FullName!));
+	}
+
+	public static void AddTransformerMatchStreamEvent(this EventLog eventlog, ITransformer tr, StreamDescription stream)
+	{
+		eventlog.AddEvent(new TransformerMatchStreamEvent(tr.GetType().FullName!, stream.ToString()));
+	}
+
+	public static void AddInformationEvent(this EventLog eventLog, string message)
+	{
+		eventLog.AddEvent(new InformationEvent(message));
+	}
+
+	public static void AddWarningEvent(this EventLog eventlog, string message)
+	{
+		eventlog.AddEvent(new WarningEvent(message));
+	}
+
+	public static void AddErrorEvent(this EventLog eventLog, Exception? exception, StreamDescription? stream = null, string? message = null)
+	{
+		eventLog.AddEvent(new ErrorEvent(exception, stream, message));
+	}
+}
+

--- a/Pansynchro.core/EventsSystem/Events/EndSyncEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/EndSyncEvent.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+
+public class EndSyncEvent : EventBase
+{
+	public EndSyncEvent(string? message = null) : base(message)
+	{
+	}
+}
+

--- a/Pansynchro.core/EventsSystem/Events/EndSyncStreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/EndSyncStreamEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class EndSyncStreamEvent : StreamEvent
+{
+	public EndSyncStreamEvent(string streamName) : base(streamName, null)
+	{
+	}
+}
+

--- a/Pansynchro.core/EventsSystem/Events/ErrorEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/ErrorEvent.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class ErrorEvent : ExceptionEvent, IStreamEvent
+{
+	public string? StreamName { get; }
+	public ErrorEvent(Exception? ex, StreamDescription? stream, string? message) : base(ex, message)
+	{
+		StreamName = stream?.ToString();
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/ExceptionEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/ExceptionEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+
+public class ExceptionEvent : EventBase
+{
+	public Exception? Exception { get; }
+	public ExceptionEvent(Exception? ex, string? message) : base(message)
+	{
+		Exception = ex;
+		LogLevel = Microsoft.Extensions.Logging.LogLevel.Error;
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/InformationEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/InformationEvent.cs
@@ -1,0 +1,17 @@
+﻿using Pansynchro.Core.EventsSystem.Events;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+
+public class InformationEvent : EventBase
+{
+	public InformationEvent(string message) : base(message)
+	{
+		LogLevel = Microsoft.Extensions.Logging.LogLevel.Information;
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/MergingStreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/MergingStreamEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class MergingStreamEvent : StreamEvent
+{
+	public MergingStreamEvent(string streamName) : base(streamName, null)
+	{
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/ReadingStreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/ReadingStreamEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class ReadingStreamEvent : StreamEvent
+{
+	public ReadingStreamEvent(string streamName, string? message = null) : base(streamName, message)
+	{
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/StartSyncEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/StartSyncEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+
+public class StartSyncEvent : EventBase
+{
+	public StartSyncEvent(string? message = null) : base(message)
+	{
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/StartSyncStreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/StartSyncStreamEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class StartSyncStreamEvent : StreamEvent
+{
+	public StartSyncStreamEvent(string streamName) : base(streamName, null)
+	{
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/StreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/StreamEvent.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class StreamEvent : EventBase, IStreamEvent
+{
+	public StreamEvent(string streamName, string? message) : base(message)
+	{
+		StreamName = streamName;
+	}
+
+	public string StreamName { get; }
+}

--- a/Pansynchro.core/EventsSystem/Events/TransformerMatchStreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/TransformerMatchStreamEvent.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class TransformerMatchStreamEvent : StreamEvent
+{
+	public TransformerMatchStreamEvent(string transformerName, string streamName) : base(streamName, null)
+	{
+		TransformerName = transformerName;
+	}
+
+	public string TransformerName { get; }
+
+	public override string ToString()
+	{
+		return $"{Name} {TransformerName} {StreamName}";
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/TruncatingStreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/TruncatingStreamEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+
+public class TruncatingStreamEvent : StreamEvent
+{
+	public TruncatingStreamEvent(string streamName) : base(streamName, null)
+	{
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/UseTransformerEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/UseTransformerEvent.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class UseTransformerEvent : EventBase
+{
+	public UseTransformerEvent(string transformerName) : base(null)
+	{
+		TransformerName = transformerName;
+	}
+
+	public string TransformerName { get; }
+
+	public override string ToString()
+	{
+		return $"{Name} {TransformerName}";
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/WarningEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/WarningEvent.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+internal class WarningEvent : EventBase
+{
+	public WarningEvent(string message) : base(message)
+	{
+		LogLevel = Microsoft.Extensions.Logging.LogLevel.Warning;
+	}
+}

--- a/Pansynchro.core/EventsSystem/Events/WritingStreamEvent.cs
+++ b/Pansynchro.core/EventsSystem/Events/WritingStreamEvent.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Pansynchro.Core.EventsSystem.Events;
+public class WritingStreamEvent : StreamEvent
+{
+	public WritingStreamEvent(string streamName) : base(streamName, null)
+	{
+	}
+}

--- a/Pansynchro.core/EventsSystem/IEvent.cs
+++ b/Pansynchro.core/EventsSystem/IEvent.cs
@@ -1,0 +1,15 @@
+﻿using Microsoft.Extensions.Logging;
+using System;
+
+namespace Pansynchro.Core.EventsSystem;
+public interface IEvent
+{
+	string Name { get; }
+	LogLevel LogLevel { get; }
+	DateTime FireOn { get; }
+}
+
+public interface IStreamEvent : IEvent
+{
+	string? StreamName { get; }
+}

--- a/Pansynchro.core/EventsSystem/LoggerExtensions.cs
+++ b/Pansynchro.core/EventsSystem/LoggerExtensions.cs
@@ -1,0 +1,17 @@
+﻿using Microsoft.Extensions.Logging;
+using Pansynchro.Core.EventsSystem;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Microsoft.Extensions.Logging;
+
+public static class LoggerExtensions
+{
+	public static void LogEvent(this ILogger logger, IEvent @event)
+	{
+		logger.Log(@event.LogLevel, @event.ToString());
+	}
+}

--- a/Pansynchro.core/ITransformer.cs
+++ b/Pansynchro.core/ITransformer.cs
@@ -4,6 +4,7 @@ using System.Data;
 using System.Threading.Tasks;
 
 using Pansynchro.Core.DataDict;
+using Pansynchro.Core.EventsSystem;
 
 namespace Pansynchro.Core
 {
@@ -38,19 +39,19 @@ namespace Pansynchro.Core
 			yield break;
 		}
 
-        protected virtual Func<IDataReader, IEnumerable<object[]>>? GetProcessor(DataStream stream)
-        {
-            return _streamDict.TryGetValue(stream.Name.ToString(), out var processor) ? processor : null;
-        }
+		protected virtual Func<IDataReader, IEnumerable<object[]>>? GetProcessor(DataStream stream)
+		{
+			return _streamDict.TryGetValue(stream.Name.ToString(), out var processor) ? processor : null;
+		}
 
-        public async IAsyncEnumerable<DataStream> Transform(IAsyncEnumerable<DataStream> input)
+		public async IAsyncEnumerable<DataStream> Transform(IAsyncEnumerable<DataStream> input)
 		{
 			await foreach (var stream in StreamFirst()) {
 				yield return stream;
 			}
+			EventLog.Instance.AddUseTransformerEvent(this);
 			await foreach (var stream in input) {
 				DataStream result;
-				Console.WriteLine($"Processing Stream: {stream.Name}");
 				if (!_nameMap.TryGetValue(stream.Name, out var destName)) {
 					if (stream.Name.Namespace == null) {
 						if (_nullNsMap != null) {
@@ -60,19 +61,16 @@ namespace Pansynchro.Core
 						destName = stream.Name with { Namespace = newNs };
 					}
 				}
-                var processor = GetProcessor(stream);
-                if (processor != null)
-                {
-                    var destStream = _destDict.GetStream(destName ?? stream.Name, NameStrategy.Get(NameStrategyType.Identity));
+				var processor = GetProcessor(stream);
+				if (processor != null) {
+					var destStream = _destDict.GetStream(destName ?? stream.Name, NameStrategy.Get(NameStrategyType.Identity));
 					if (destStream == null) {
-						Console.WriteLine($"Stream name '{destName}' not found in data dictionary");
 						result = stream;
 					} else {
-						Console.WriteLine("Stream found");
+						EventLog.Instance.AddTransformerMatchStreamEvent(this, stream.Name);
 						result = stream.Transformed(processor, destStream);
 					}
 				} else {
-					Console.WriteLine("Stream not found");
 					result = stream;
 				}
 				yield return destName != null ? result with { Name = destName } : result;

--- a/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLogger.cs
+++ b/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLogger.cs
@@ -1,0 +1,69 @@
+﻿using Microsoft.Extensions.Logging;
+using Pansynchro.Core.EventsSystem;
+using System;
+using System.Linq;
+
+namespace Pansynchro.Core.Logs.ColorConsoleLogger;
+
+public sealed class ColorConsoleLogger : ILogger
+{
+	private readonly string _name;
+	private readonly Func<ColorConsoleLoggerConfiguration> _getCurrentConfig;
+
+	public ColorConsoleLogger(string name, Func<ColorConsoleLoggerConfiguration> getCurrentConfig)
+	{
+		this._name = name;
+		this._getCurrentConfig = getCurrentConfig;
+	}
+	public IDisposable? BeginScope<TState>(TState state) where TState : notnull => default!;
+
+	public bool IsEnabled(LogLevel logLevel) =>
+		_getCurrentConfig().LogLevelToColorMap.ContainsKey(logLevel);
+
+	private static string MessageFormatter(string? message, Exception? error)
+	{
+		if (message == null) {
+			if (error == null) {
+				return "Empty Error";
+			}
+			return error.ToString();
+		}
+		if (error == null) {
+			return message;
+		}
+		return $"{message}\n{error.ToString()}";
+	}
+
+	public void Log<TState>(
+		LogLevel logLevel,
+		EventId eventId,
+		TState state,
+		Exception? exception,
+		Func<TState, Exception?, string> formatter)
+	{
+		if (!EventLog.Instance.ConsoleOutput) {
+			return;
+		}
+
+		if (!IsEnabled(logLevel)) {
+			return;
+		}
+
+		ColorConsoleLoggerConfiguration config = _getCurrentConfig();
+		if (config.EventId == 0 || config.EventId == eventId.Id) {
+			var originalColor = Console.ForegroundColor;
+			ConsoleColor foregroundColor;
+			if (!config.LogLevelToColorMap.TryGetValue(logLevel, out foregroundColor))
+				foregroundColor = ConsoleColor.White;
+			var logLevelStr = logLevel.ToString().Substring(0, Math.Min(logLevel.ToString().Length, 4)).ToUpper();
+
+			Console.Write($"{DateTime.Now}-{_name}: ");
+
+			Console.ForegroundColor = foregroundColor;
+			Console.Write($"[{logLevelStr,-4}] {ColorConsoleLogger.MessageFormatter(state?.ToString(), exception)}");
+
+			Console.ForegroundColor = originalColor;
+			Console.WriteLine();
+		}
+	}
+}

--- a/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLoggerConfiguration.cs
+++ b/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLoggerConfiguration.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+
+namespace Pansynchro.Core.Logs.ColorConsoleLogger;
+
+public sealed class ColorConsoleLoggerConfiguration
+{
+	public int EventId { get; set; }
+
+	public Dictionary<LogLevel, ConsoleColor> LogLevelToColorMap { get; set; } = new() {
+		[LogLevel.Information] = ConsoleColor.Green,
+		[LogLevel.Trace] = ConsoleColor.Blue,
+		[LogLevel.Debug] = ConsoleColor.White,
+		[LogLevel.Warning] = ConsoleColor.Yellow,
+		[LogLevel.Error] = ConsoleColor.Red,
+		[LogLevel.Critical] = ConsoleColor.DarkRed,
+		[LogLevel.None] = ConsoleColor.White
+	};
+}

--- a/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLoggerExtensions.cs
+++ b/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLoggerExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Configuration;
+using Pansynchro.Core.Logs.ColorConsoleLogger;
+
+namespace Pansynchro.Core.Logs.ColorConsoleLogger;
+
+public static class ColorConsoleLoggerExtensions
+{
+	public static ILoggingBuilder AddColorConsoleLogger(
+		this ILoggingBuilder builder)
+	{
+		builder.AddConfiguration();
+
+		builder.Services.TryAddEnumerable(
+			ServiceDescriptor.Singleton<ILoggerProvider, ColorConsoleLoggerProvider>());
+
+		LoggerProviderOptions.RegisterProviderOptions
+			<ColorConsoleLoggerConfiguration, ColorConsoleLoggerProvider>(builder.Services);
+
+		return builder;
+	}
+
+	public static ILoggingBuilder AddColorConsoleLogger(
+		this ILoggingBuilder builder,
+		Action<ColorConsoleLoggerConfiguration> configure)
+	{
+		builder.AddColorConsoleLogger();
+		builder.Services.Configure(configure);
+
+		return builder;
+	}
+}

--- a/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLoggerProvider.cs
+++ b/Pansynchro.core/Logs/ColorConsoleLogger/ColorConsoleLoggerProvider.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.Versioning;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+
+namespace Pansynchro.Core.Logs.ColorConsoleLogger;
+
+[UnsupportedOSPlatform("browser")]
+[ProviderAlias("ColorConsole")]
+public sealed class ColorConsoleLoggerProvider : ILoggerProvider
+{
+	private readonly IDisposable? _onChangeToken;
+	private ColorConsoleLoggerConfiguration _currentConfig;
+	private readonly ConcurrentDictionary<string, ColorConsoleLogger> _loggers =
+		new(StringComparer.OrdinalIgnoreCase);
+
+	public ColorConsoleLoggerProvider(
+		IOptionsMonitor<ColorConsoleLoggerConfiguration> config)
+	{
+		_currentConfig = config.CurrentValue;
+		_onChangeToken = config.OnChange(updatedConfig => _currentConfig = updatedConfig);
+	}
+
+	public ILogger CreateLogger(string categoryName) =>
+		_loggers.GetOrAdd(categoryName, name => new ColorConsoleLogger(name, GetCurrentConfig));
+
+	private ColorConsoleLoggerConfiguration GetCurrentConfig() => _currentConfig;
+
+	public void Dispose()
+	{
+		_loggers.Clear();
+		_onChangeToken?.Dispose();
+	}
+}

--- a/Pansynchro.core/Pansynchro.Core.csproj
+++ b/Pansynchro.core/Pansynchro.Core.csproj
@@ -38,6 +38,9 @@
 	<PackageReference Include="Antlr4.Runtime.Standard" Version="4.13.1" />
 	<PackageReference Include="Antlr4BuildTasks" Version="12.7.0" PrivateAssets="all" IncludeAssets="build" />
 	<PackageReference Include="DotNet.Glob" Version="3.1.3" />
+	<PackageReference Include="Microsoft.Extensions.Logging" Version="8.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Logging.Configuration" Version="8.0.0" />
 	<PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
 	<PackageReference Include="System.Linq.Async" Version="6.0.1" />
   </ItemGroup>

--- a/Pansynchro.core/ProcessHelper.cs
+++ b/Pansynchro.core/ProcessHelper.cs
@@ -27,11 +27,13 @@ namespace Pansynchro.Core
                     RedirectStandardOutput = outputTextWriter != null,
                     RedirectStandardError = errorTextWriter != null,
                     UseShellExecute = false,
-                    WorkingDirectory = workingDirectory ?? "",
-                    LoadUserProfile = true
+                    WorkingDirectory = workingDirectory ?? ""
                 }
             })
             {
+                if (OperatingSystem.IsWindows()) {
+                    process.StartInfo.LoadUserProfile = true;
+                }
                 var cancellationTokenSource = timeout.HasValue ?
                     new CancellationTokenSource(timeout.Value) :
                     new CancellationTokenSource();


### PR DESCRIPTION
This PR comes from some conversations on Discord.

At the first hand I needed to transform all tables from a database searching for 0x00 special chars on source, for this we add a `GetProcessor` method on `StreamTransformerBase` from `ITransformer` file.

The second thing was perform table mergin, on PostgreSQL, without any PK columns. If you don't have PK colums you don't know what to keep and what to update ... speaking on Discord accord to copy entire data and leave in user the possibility of delete data before sync. That is done only for PostgreSQL, I couldn't try on others.

At the last is something that came up talking about localize what tables have special chars. I needed continue on error feature, but I have 1800 tables in my database, the console output is not sufficient, then  I thought about have an event log where the pansynchro records what happens in the process, in order to save this information to disk at the end or ... sent by email ... what ever else.